### PR TITLE
Show item title on cartwall buttons

### DIFF
--- a/com.mairlist.automation.sdPlugin/manifest.json
+++ b/com.mairlist.automation.sdPlugin/manifest.json
@@ -10,7 +10,7 @@
   "Category": "mAirList", 
   "CategoryIcon": "icons/category", 
   "URL": "https://www.mairlist.com", 
-  "Version": "1.4",
+  "Version": "1.4.1",
   "OS": [
     {
         "Platform": "mac", 

--- a/com.mairlist.automation.sdPlugin/manifest.json
+++ b/com.mairlist.automation.sdPlugin/manifest.json
@@ -31,6 +31,7 @@
       "UUID": "com.mairlist.automation.actions.cart",
       "Name": "Cart Player", 
       "Icon": "icons/actions/cart", 
+      "UserTitleEnabled": false,
       "States": [
         {
           "Image": "icons/state/cart",

--- a/com.mairlist.automation.sdPlugin/pi/index.html
+++ b/com.mairlist.automation.sdPlugin/pi/index.html
@@ -18,6 +18,11 @@
         <input class="sdpi-item-value" id="cart-number" inputmode="numeric" pattern="[0-9]*" type="number" onChange="updateSettings()">
       </div>
       <div class="sdpi-item" type="checkbox">
+        <div class="sdpi-item-label">Show Title</div>
+        <input class="sdpi-item-value" id="cart-show-text" type="checkbox" value="1" onChange="updateSettings()">
+        <label for="cart-show-text"><span></span>Show Title of Item in cart</label>
+      </div>    
+      <div class="sdpi-item" type="checkbox">
         <div class="sdpi-item-label">Ignore State</div>
         <input class="sdpi-item-value" id="cart-alwaysOn" type="checkbox" value="1" onChange="updateSettings()">
         <label for="cart-alwaysOn"><span></span>Enable button when OFF AIR</label>

--- a/com.mairlist.automation.sdPlugin/pi/js/pi.js
+++ b/com.mairlist.automation.sdPlugin/pi/js/pi.js
@@ -18,6 +18,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
       document.getElementById("settings-cart").style.display = "block";
       document.getElementById("cart-number").value = settings.number || "";
       document.getElementById("cart-alwaysOn").checked = settings.alwaysOn;
+      document.getElementById("cart-show-text").checked = settings.showText;
       break;
     case ACTION_COMMAND:
       document.getElementById("settings-command").style.display = "block";
@@ -96,6 +97,7 @@ function updateSettings() {
     case ACTION_CART:
       settings.number = document.getElementById("cart-number").value;
       settings.alwaysOn = document.getElementById("cart-alwaysOn").checked;
+      settings.showText= document.getElementById("cart-show-text").checked;
       break;
     case ACTION_COMMAND:
       settings.command = document.getElementById("command-command").value;

--- a/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
@@ -8,13 +8,13 @@ class CartAction extends Action {
     super.update();
   
     // Check is the cart number is configured
-    var cartIndex = this.settings.number;
-    if (cartIndex == undefined) {
+    const cartIndex = this.settings.number;
+    if (cartIndex === undefined) {
       return;
     }
   
     // Determine color
-    var color;
+    let color;
   
     if (! this.connection.connected)
       color = "black"
@@ -25,34 +25,33 @@ class CartAction extends Action {
             )
       color = "black"
     else 
-      switch (this.connection.cartPlayerStates[cartIndex]) {
+      switch (this.connection.cartPlayerStates[cartIndex].state) {
         case "Playing":
-          color = "red";
+          color = "#E74C3C";
           break;
         case "Fading":
-          color = "red";
+          color = "#E67E22";
           break;
         case "Stopped":
-          color = "green";
+          color = "#27AE60";
           break;
         default:
-          color = "black";
+          color = "#7F8C8D";
       }
       
       
     // Generate SVG
-    var fontSize = 64;
-    var textY = 70;
-    if ((this.connection.cartPlayerStates.length >= 10) || (cartIndex >= 10)) {
-      fontSize = 48;
-      textY = 62;
-    }
-    var svg = 
-      "data:image/svg+xml;charset=utf8," +
-      "<svg height=\"100\" width=\"100\">" +
-      "<circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"" + color + "\" />" +
-      "<text x=\"50\" y=\"" + textY + "\" text-anchor=\"middle\" font-size=\"" + fontSize + "px\" font-weight=\"bold\" fill=\"white\">" + cartIndex + "</text>" +
-      "</svg>";
+    let cartText = this.connection.cartPlayerStates[cartIndex].title
+    const noTitle = cartText === ""
+    const fontSize = noTitle ?  64 : 17;
+    cartText = noTitle ? cartIndex : cartText;
+    
+    const svg = 
+      `data:image/svg+xml;charset=utf8,
+      <svg height="100" width="100">
+      <rect x="5" y="5" width="90" height="90" rx="15" stroke="none" stroke-width="0" fill="${color}" />
+      <textArea x="6" y="10" width="88" height="90" alignment-baseline="middle" text-anchor="middle" font-size="${fontSize}px" font-weight="bold" fill="white"> ${cartText} </textArea>
+      </svg>`;
 
     // Send to SD  
     this.connection.sendToSD({

--- a/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
@@ -15,6 +15,8 @@ class CartAction extends Action {
   
     // Determine color
     let color;
+    let cartText = cartIndex
+    let fontSize = 64
   
     if (! this.connection.connected)
       color = "black"
@@ -41,10 +43,12 @@ class CartAction extends Action {
       
       
     // Generate SVG
-    let cartText = this.connection.cartPlayerStates[cartIndex].title
-    const noTitle = cartText === ""
-    const fontSize = noTitle ?  64 : 17;
-    cartText = noTitle ? cartIndex : cartText;
+    if (this.connection.connected) {
+      if (this.connection.cartPlayerStates[cartIndex].title !== "") {
+        cartText = this.connection.cartPlayerStates[cartIndex].title;
+        fontSize = 17;
+      }
+    }
     
     const svg = 
       `data:image/svg+xml;charset=utf8,

--- a/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/actions/cart.js
@@ -44,7 +44,7 @@ class CartAction extends Action {
       
     // Generate SVG
     if (this.connection.connected) {
-      if (this.connection.cartPlayerStates[cartIndex].title !== "") {
+      if (this.connection.cartPlayerStates[cartIndex].title !== "" && this.settings.showText) {
         cartText = this.connection.cartPlayerStates[cartIndex].title;
         fontSize = 17;
       }

--- a/com.mairlist.automation.sdPlugin/plugin/js/app.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/app.js
@@ -3,7 +3,7 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
   var upstream = null;
 
   // Open the web socket
-  var websocket = new WebSocket("ws://127.0.0.1:" + inPort);
+  const websocket = new WebSocket("ws://127.0.0.1:" + inPort);
 
   websocket.onopen = function() {
     // Register

--- a/com.mairlist.automation.sdPlugin/plugin/js/connection.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/connection.js
@@ -108,11 +108,13 @@ class UpstreamConnection {
     const m = msg.p.match(/^Cartwall\/Players\/Player (\d+)\/(.*)/);
 
     if (m) {
-      var idx = m[1];
-      var param = m[2];
-    
-      if (param == 'State') {
-        this.cartPlayerStates[idx] = msg.v;
+      const idx = m[1];
+      const param = m[2];
+      if(!this.cartPlayerStates[idx]) {
+        this.cartPlayerStates[idx] = {}
+      }
+      if (param == 'State' || param === 'Title') {
+        this.cartPlayerStates[idx][param.toLowerCase()] = msg.v;
         
         for (const ctx in this.actions[ACTION_CART]) {
           const action = this.actions[ACTION_CART][ctx];

--- a/com.mairlist.automation.sdPlugin/plugin/js/connection.js
+++ b/com.mairlist.automation.sdPlugin/plugin/js/connection.js
@@ -49,7 +49,7 @@ class UpstreamConnection {
 
     var host = this.settings.host || DEFAULT_HOST;
     var port = this.settings.port || DEFAULT_PORT;
-    var url = "ws://" + host + ":" + port + "/ws";
+    var url = `ws://${host}:${port}/ws`;
 
     console.log("Upstream connecting to " + url);
 
@@ -77,7 +77,7 @@ class UpstreamConnection {
     }
   
     this.websocket.onmessage = (evt) => {
-      var msg = JSON.parse(evt.data);
+      const msg = JSON.parse(evt.data);
     
       if (msg.msg == 'state') {
         this.handleStateMessage(msg);
@@ -105,7 +105,7 @@ class UpstreamConnection {
       return;
     }
     
-    var m = msg.p.match(/^Cartwall\/Players\/Player (\d+)\/(.*)/);
+    const m = msg.p.match(/^Cartwall\/Players\/Player (\d+)\/(.*)/);
 
     if (m) {
       var idx = m[1];
@@ -127,7 +127,7 @@ class UpstreamConnection {
   
   // Called when an action appears
   willAppear(data) {
-    var action = null;
+    let action;
     
     // Create action object, based on type
     switch (data.action) {
@@ -179,7 +179,7 @@ class UpstreamConnection {
   // Called when new global settings are received 
   didReceiveGlobalSettings(settings) {
   
-    var mustReconnect = 
+    const mustReconnect = 
       (this.settings.host != settings.host) ||
       (this.settings.port != settings.port);
       


### PR DESCRIPTION
I changed `cartPlayerStates[cartIndex]` to an object containing both the state and the title, and read the title into the SVG directly from there. This was done by using the parameter names directly from the read packet making expansion to add selected cart or artist support very easy.
Changed the element in the SVG from a `text` element to a `textArea` to support wrapping for long titles.
Changed the colors in the buttons to match hex codes from within the mairlist color list

While going over the project I replaced some of the keywords etc to be a little more modern js, including `const` and `let` instead of `var`, and using template literals instead of concatenating strings, to make it all more readable and better scoped.